### PR TITLE
fix: disable Object freeze in SSR mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
   ],
   "homepage": "https://github.com/marko-js/tags-api-preview",
   "keywords": [
-    "marko",
-    "tags",
     "api",
-    "preview"
+    "marko",
+    "preview",
+    "tags"
   ],
   "license": "MIT",
   "main": "marko.json",

--- a/src/__tests__/fixtures/const/__snapshots__/const-mutation-error/node.render.error.expected.txt
+++ b/src/__tests__/fixtures/const/__snapshots__/const-mutation-error/node.render.error.expected.txt
@@ -1,1 +1,0 @@
-Cannot add property fullName, object is not extensible

--- a/src/__tests__/fixtures/const/__snapshots__/const-mutation-error/node.render.expected.html
+++ b/src/__tests__/fixtures/const/__snapshots__/const-mutation-error/node.render.expected.html
@@ -1,0 +1,3 @@
+<p>
+  George R.R. Martin
+</p>

--- a/src/util/deep-freeze/index-browser.ts
+++ b/src/util/deep-freeze/index-browser.ts
@@ -1,0 +1,10 @@
+export = function deepFreeze(val: unknown) {
+  if (!Object.isFrozen(val) && typeof val !== "function") {
+    Object.freeze(val);
+    for (const key in val as Record<string, unknown>) {
+      deepFreeze((val as Record<string, unknown>)[key]);
+    }
+  }
+
+  return val;
+};

--- a/src/util/deep-freeze/index.ts
+++ b/src/util/deep-freeze/index.ts
@@ -1,10 +1,3 @@
 export = function deepFreeze(val: unknown) {
-  if (!Object.isFrozen(val) && typeof val !== "function") {
-    Object.freeze(val);
-    for (const key in val as Record<string, unknown>) {
-      deepFreeze((val as Record<string, unknown>)[key]);
-    }
-  }
-
   return val;
 };

--- a/src/util/deep-freeze/package.json
+++ b/src/util/deep-freeze/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "./index",
+  "browser": "./index-browser"
+}


### PR DESCRIPTION
## Description
This PR disable `Object.freeze` for tag variables in SSR mode. This is not ideal since the intended API is to freeze everything and enforce mutations through the tags api. However there is not a good alternative work around we've discovered at this point when targeting Marko 5's API so this will do for now!

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
