### PR TITLE
fix: eventhandler hoisting with refs

### DIFF
--- a/src/transform/hoist-tag-vars/index-browser.ts
+++ b/src/transform/hoist-tag-vars/index-browser.ts
@@ -71,6 +71,7 @@ function createHoist(owner: Component, name: string, hoister: Hoister) {
     } else if (isRendering()) {
       throw new ReferenceError(`Cannot access '${name}' before initialization`);
     }
+    return val;
   };
 }
 

--- a/src/transform/hoist-tag-vars/transform.ts
+++ b/src/transform/hoist-tag-vars/transform.ts
@@ -62,10 +62,11 @@ export default {
                 case ReferenceType.Unknown:
                   maybeHasSyncRefsBefore = true;
                   ref.replaceWith(
-                    t.sequenceExpression([
-                      t.callExpression(hoistedId, []),
+                    t.assignmentExpression(
+                      "=",
                       ref.node as t.Identifier,
-                    ])
+                      t.callExpression(hoistedId, [])
+                    )
                   );
                   break;
               }


### PR DESCRIPTION
This PR fixes an issue with pulling event handlers out of the markup into `const` tags that reference DOM refs.

## Description

The scenario being fixed here is when you use patterns like:
```marko
<attrs/{ addNewTodo } />
<const/handleSubmit(e) {
  const titleInput = title();
  addNewTodo({ title: titleInput.value });
  titleInput.value = "";
  e.preventDefault();
}/>
<header.header>
  <h1>todos</h1>
  <form onSubmit=handleSubmit>
    <input/title
      class="new-todo"
      placeholder="What needs to be done?"
    />
  </form>
</header>
```
The const gets invalidated when its internal state updates but the ref hoisting had created a stale closure over the initial render. For these cached functions now we will assign the current reference when the ref is accessed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
