### PR TITLE
fix: support receiving events from class api templates

### DIFF
--- a/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/node.render.expected.html
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/node.render.expected.html
@@ -1,0 +1,6 @@
+<button>
+  emit 1
+</button>
+<button>
+  emit 2
+</button>

--- a/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/web.render.expected.html
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/web.render.expected.html
@@ -1,0 +1,6 @@
+<button>
+  emit 1
+</button>
+<button>
+  emit 2
+</button>

--- a/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/web.step-0.expected.html
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/__snapshots__/misc-native-tag-event-handlers/basic/web.step-0.expected.html
@@ -1,0 +1,6 @@
+<button>
+  emit 1
+</button>
+<button>
+  emit 2
+</button>

--- a/src/__tests__/fixtures/misc/class-api-event-handlers/index.test.ts
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/index.test.ts
@@ -1,0 +1,25 @@
+import { spy, resetHistory } from "sinon";
+import fixture from "../../../fixture";
+
+const onValue = spy();
+
+describe("misc native tag event handlers", () => {
+  describe(
+    "basic",
+    fixture("./templates/basic.marko", [
+      { onValue },
+      async ({ expect, fireEvent, screen }) => {
+        expect(onValue).has.not.been.called;
+
+        await fireEvent.click(screen.getByText("emit 1"));
+
+        expect(onValue).has.been.calledOnceWith(1);
+        resetHistory();
+
+        await fireEvent.click(screen.getByText("emit 2"));
+        expect(onValue).has.been.calledOnceWith(2);
+        resetHistory();
+      },
+    ])
+  );
+});

--- a/src/__tests__/fixtures/misc/class-api-event-handlers/templates/basic.marko
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/templates/basic.marko
@@ -1,0 +1,3 @@
+<attrs/{ onValue }/>
+<fancy-button onClick=(() => onValue(1))>emit 1</fancy-button>
+<fancy-button onClick=(() => onValue(2))>emit 2</fancy-button>

--- a/src/__tests__/fixtures/misc/class-api-event-handlers/templates/components/fancy-button.marko
+++ b/src/__tests__/fixtures/misc/class-api-event-handlers/templates/components/fancy-button.marko
@@ -1,0 +1,9 @@
+class {
+  handleClick() {
+    this.emit("click");
+  }
+}
+
+<button onClick("handleClick")>
+  <${input.renderBody}/>
+</button>

--- a/src/translate/class-api-custom-tag-handlers.ts
+++ b/src/translate/class-api-custom-tag-handlers.ts
@@ -1,0 +1,29 @@
+import { types as t } from "@marko/compiler";
+import { loadFileForTag } from "@marko/babel-utils";
+import isApi from "../util/is-api";
+const eventNameReg = /^on[A-Z]/;
+
+// Translates all event handlers that are on class api child tags to use the `onEvent(handler)` api.
+// This allows tags api templates to consume events from class api templates.
+export default {
+  MarkoTag(tag: t.NodePath<t.MarkoTag>) {
+    if (isApi(tag, "class")) return;
+    let childFile: t.BabelFile | undefined;
+
+    for (const attr of tag.get("attributes")) {
+      if (
+        attr.isMarkoAttribute() &&
+        !attr.node.arguments &&
+        eventNameReg.test(attr.node.name)
+      ) {
+        if (
+          !(childFile ||= loadFileForTag(tag)) ||
+          isApi(childFile.path, "tags")
+        )
+          return;
+        attr.node.arguments = [attr.node.value];
+        attr.node.value = t.booleanLiteral(true);
+      }
+    }
+  },
+} as t.Visitor;

--- a/src/translate/index.ts
+++ b/src/translate/index.ts
@@ -1,5 +1,12 @@
 import { types as t } from "@marko/compiler";
+import classApiCustomTagHandlers from "./class-api-custom-tag-handlers";
 import nativeTagHandlers from "./native-tag-handlers/translate";
 import trackRendering from "./track-rendering/translate";
 import forKeyScope from "./for-key-scope";
-export = [nativeTagHandlers, trackRendering, forKeyScope] as t.Visitor[];
+
+export = [
+  classApiCustomTagHandlers,
+  nativeTagHandlers,
+  trackRendering,
+  forKeyScope,
+] as t.Visitor[];


### PR DESCRIPTION
## Description

Currently it is not possible to receive events from a `class api` template if you are writing a `tags api` template.
This PR adds support for this. You can now use the tags api event api (eg `onClick=handleClick`) and it will setup the event handlers if the child component is using the `class api`.

fixes #4 

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
