### PR TITLE
fix: add support for element refs on dynamic tags

### DIFF
--- a/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/node.render.expected.html
+++ b/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/node.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+  Hello
+</div>

--- a/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/web.render.expected.html
+++ b/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/web.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+  Hello
+</div>

--- a/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/web.step-0.expected.html
+++ b/src/__tests__/fixtures/misc/dynamic-tag-var/__snapshots__/misc-dynamic-tag-vars/basic/web.step-0.expected.html
@@ -1,0 +1,3 @@
+<div>
+  Hello
+</div>

--- a/src/__tests__/fixtures/misc/dynamic-tag-var/index.test.ts
+++ b/src/__tests__/fixtures/misc/dynamic-tag-var/index.test.ts
@@ -1,0 +1,21 @@
+import { spy, resetHistory } from "sinon";
+import fixture from "../../../fixture";
+
+const onValue = spy();
+
+describe("misc dynamic tag vars", () => {
+  describe(
+    "basic",
+    fixture("./templates/basic.marko", [
+      { onValue },
+      ({ expect }) => {
+        expect(onValue)
+          .to.be.calledOnce.with.property("args")
+          .with.property("0")
+          .with.property("0")
+          .that.has.text("Hello");
+        resetHistory();
+      },
+    ])
+  );
+});

--- a/src/__tests__/fixtures/misc/dynamic-tag-var/templates/basic.marko
+++ b/src/__tests__/fixtures/misc/dynamic-tag-var/templates/basic.marko
@@ -1,0 +1,4 @@
+<attrs/{ onValue }/>
+<effect=(() => onValue(el()))/>
+<const/name="div"/>
+<${name}/el>Hello</>

--- a/src/transform/cached-function/transform.ts
+++ b/src/transform/cached-function/transform.ts
@@ -1,4 +1,4 @@
-import { importNamed, isNativeTag } from "@marko/babel-utils";
+import { importNamed, isNativeTag, isDynamicTag } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import { Visitor } from "@marko/compiler/babel-types";
 import { ensureLifecycle } from "../wrapper-component";
@@ -16,7 +16,10 @@ const depsVisitor = {
     if (binding) {
       const bindingTag = binding.path;
 
-      if (bindingTag.isMarkoTag() && !isNativeTag(bindingTag)) {
+      if (
+        bindingTag.isMarkoTag() &&
+        !(isNativeTag(bindingTag) || isDynamicTag(bindingTag))
+      ) {
         let isDep = false;
 
         if (isCoreTag("const", binding.path)) {

--- a/src/transform/native-tag-var/transform.ts
+++ b/src/transform/native-tag-var/transform.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { importDefault, isNativeTag } from "@marko/babel-utils";
+import { importDefault, isNativeTag, isDynamicTag } from "@marko/babel-utils";
 import { closest } from "../wrapper-component";
 
 export default {
@@ -11,7 +11,7 @@ export default {
       } = tag;
       const tagVar = node.var!;
 
-      if (!tagVar || !isNativeTag(tag)) {
+      if (!tagVar || !(isNativeTag(tag) || isDynamicTag(tag))) {
         return;
       }
 
@@ -42,7 +42,7 @@ export default {
       tag.pushContainer("attributes", t.markoAttribute("key", keyString));
     },
     exit(tag) {
-      if (tag.node.var && isNativeTag(tag)) {
+      if (tag.node.var && (isNativeTag(tag) || isDynamicTag(tag))) {
         // Don't remove the tag variable until it has been hoisted.
         tag.node.var = null;
       }


### PR DESCRIPTION
## Description

Currently using the dynamic tag does not support tag variables whatsoever.

This PR adds support for dynamic tags with tag variables when the dynamic tag itself is for a native tag.

Eg the following is supported:

```marko
<attrs/{ isLink }/>
<const/tagName = isLink ? "a" : "button"/>

<${isLink ? "a" : "button"}/getEl/>

<effect() {
  console.log(getEl());
}/>
```

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
