### PR TITLE
fix: get tag not updating when set tag context is changed

### DIFF
--- a/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/node.render.expected.html
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/node.render.expected.html
@@ -1,0 +1,6 @@
+<div>
+  1
+</div>
+<button>
+  increment
+</button>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/web.render.expected.html
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/web.render.expected.html
@@ -1,0 +1,6 @@
+<div>
+  1
+</div>
+<button>
+  increment
+</button>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/web.step-0.expected.html
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/get-set-update-provided-value/web.step-0.expected.html
@@ -1,0 +1,6 @@
+<div>
+  2
+</div>
+<button>
+  increment
+</button>

--- a/src/__tests__/fixtures/get-and-set/index.test.ts
+++ b/src/__tests__/fixtures/get-and-set/index.test.ts
@@ -70,6 +70,15 @@ describe(
 );
 
 describe(
+  "<get> & <set> update provided value",
+  fixture("./templates/update-provided-value/index.marko", [
+    async ({ screen, fireEvent }) => {
+      await fireEvent.click(screen.getByText("increment"));
+    },
+  ])
+);
+
+describe(
   "<get> & <set> reference by tag name",
   fixture("./templates/reference-by-tag-name/index.marko")
 );

--- a/src/__tests__/fixtures/get-and-set/templates/update-provided-value/components/child.marko
+++ b/src/__tests__/fixtures/get-and-set/templates/update-provided-value/components/child.marko
@@ -1,0 +1,2 @@
+<get/val="../index.marko"/>
+<div>${val}</div>

--- a/src/__tests__/fixtures/get-and-set/templates/update-provided-value/index.marko
+++ b/src/__tests__/fixtures/get-and-set/templates/update-provided-value/index.marko
@@ -1,0 +1,6 @@
+<let/value=1 />
+
+<set=value>
+  <child/>
+  <button onClick=(() => value = 2)>increment</button>
+</set>

--- a/src/components/get/index.marko
+++ b/src/components/get/index.marko
@@ -26,7 +26,7 @@ class {
 
     if (this.provider) {
       if (typeof window === "object") {
-        this.sub = this.subscribeTo(this.provider).on("___change", this.sync);
+        this.sub = this.subscribeTo(this.provider).on("___changed", this.sync);
       }
 
       this.data = this.provider.input;

--- a/src/components/set/index.marko
+++ b/src/components/set/index.marko
@@ -28,8 +28,7 @@ $ {
 <${input.renderBody}/>
 
 $ {
-  if (typeof window === "object" && !component.___rendered) {
-    component.___rendered = true;
+  if (typeof window === "object" && typeof component.emit === "function") {
     component.emit("___changed");
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail.  Include the package name if applicable. -->
Fixes a bug in the get tag not updating when the value in the provider set tag updates.

Wasn't too sure about how to do the tests, sorry if I overcomplicated it or made a mistake here.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #9 

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
