### PR TITLE
fix: ensure let is never treated as a const in the browser

### DIFF
--- a/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/node.render.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/node.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+   Copy: 1 Value: 1
+</div>

--- a/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.render.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+   Copy: 1 Value: 1
+</div>

--- a/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.step-0.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.step-0.expected.html
@@ -1,0 +1,3 @@
+<div>
+   Copy: 1 Value: 2
+</div>

--- a/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.step-1.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-without-assignments-saves-initial-value/web.step-1.expected.html
@@ -1,0 +1,3 @@
+<div>
+   Copy: 1 Value: 3
+</div>

--- a/src/__tests__/fixtures/let/index.test.ts
+++ b/src/__tests__/fixtures/let/index.test.ts
@@ -157,6 +157,15 @@ describe(
   fixture("./templates/error-no-tag-var.marko")
 );
 
+describe(
+  "<let> without assignments saves initial value",
+  fixture("./templates/without-assignments-saves-initial-value.marko", [
+    { value: 1 },
+    { value: 2 },
+    { value: 3 },
+  ])
+);
+
 function click(text: string) {
   return async ({ fireEvent, screen }: FixtureHelpers) =>
     await fireEvent.click(screen.getByText(text));

--- a/src/__tests__/fixtures/let/templates/without-assignments-saves-initial-value.marko
+++ b/src/__tests__/fixtures/let/templates/without-assignments-saves-initial-value.marko
@@ -1,0 +1,6 @@
+<attrs/{ value }/>
+<div>
+  <let/copy=value/>
+  Copy: ${copy}
+  Value: ${value}
+</div>

--- a/src/components/let/translate.ts
+++ b/src/components/let/translate.ts
@@ -50,7 +50,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
   file.path.scope.crawl();
   const binding = tag.scope.getBinding(tagVar.name)!;
 
-  if (server || !binding.constantViolations.length) {
+  if (server) {
     file.path.scope.crawl();
     tag.replaceWith(
       t.variableDeclaration("const", [


### PR DESCRIPTION
## Description

Fixes a bug with the `<let>` tag where it was being erroneously turned into a `const` if there were no assignments.
This is fine when the `<let>` is compiled for the server, but in the browser it should always save an initial value.

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
