### PR TITLE
feat: allow missing default attribute for let tag

### DIFF
--- a/.changeset/metal-boxes-wash.md
+++ b/.changeset/metal-boxes-wash.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Allow missing default attribute for let tag.

--- a/src/__tests__/fixtures/let/__snapshots__/let-error-no-default-attr/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/let/__snapshots__/let-error-no-default-attr/node.compile.error.expected.txt
@@ -1,5 +1,0 @@
-src/__tests__/fixtures/let/templates/error-no-default-attr.marko(1,2): The <let> tag must be initialized with a value.
-> 1 | <let/count/>
-    |  ^^^
-  2 | <div>${count}</div>
-  3 |

--- a/src/__tests__/fixtures/let/__snapshots__/let-error-no-default-attr/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/let/__snapshots__/let-error-no-default-attr/web.compile.error.expected.txt
@@ -1,5 +1,0 @@
-src/__tests__/fixtures/let/templates/error-no-default-attr.marko(1,2): The <let> tag must be initialized with a value.
-> 1 | <let/count/>
-    |  ^^^
-  2 | <div>${count}</div>
-  3 |

--- a/src/__tests__/fixtures/let/__snapshots__/let-no-default-attr/node.render.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-no-default-attr/node.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+  undefined
+</div>

--- a/src/__tests__/fixtures/let/__snapshots__/let-no-default-attr/web.render.expected.html
+++ b/src/__tests__/fixtures/let/__snapshots__/let-no-default-attr/web.render.expected.html
@@ -1,0 +1,3 @@
+<div>
+  undefined
+</div>

--- a/src/__tests__/fixtures/let/index.test.ts
+++ b/src/__tests__/fixtures/let/index.test.ts
@@ -125,6 +125,8 @@ describe(
   ])
 );
 
+describe("<let> no default attr", fixture("./templates/no-default-attr.marko"));
+
 describe("<let> error args", fixture("./templates/error-args.marko"));
 
 describe(
@@ -145,11 +147,6 @@ describe(
 describe(
   "<let> error extra attr",
   fixture("./templates/error-extra-attr.marko")
-);
-
-describe(
-  "<let> error no default attr",
-  fixture("./templates/error-no-default-attr.marko")
 );
 
 describe(

--- a/src/__tests__/fixtures/let/templates/error-no-default-attr.marko
+++ b/src/__tests__/fixtures/let/templates/error-no-default-attr.marko
@@ -1,2 +1,0 @@
-<let/count/>
-<div>${count}</div>

--- a/src/__tests__/fixtures/let/templates/no-default-attr.marko
+++ b/src/__tests__/fixtures/let/templates/no-default-attr.marko
@@ -1,0 +1,2 @@
+<let/value/>
+<div>${typeof value}</div>

--- a/src/util/deep-freeze/transform.ts
+++ b/src/util/deep-freeze/transform.ts
@@ -2,7 +2,12 @@ import { types as t } from "@marko/compiler";
 import { importDefault } from "@marko/babel-utils";
 
 export default (file: t.BabelFile, value: t.Expression) => {
-  if (file.markoOpts.optimize || t.isLiteral(value)) {
+  if (
+    file.markoOpts.optimize ||
+    t.isLiteral(value) ||
+    t.isBinaryExpression(value) ||
+    t.isUnaryExpression(value)
+  ) {
     return value;
   }
 


### PR DESCRIPTION
## Description

The `<let>` tag was needlessly restricted to require a default attribute, so if you had `<let/x/>` it'd error instead of just initializing as undefined.

This PR updates it to no longer error in that case.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
