### PR TITLE
fix: add _return as a global attribute

### DIFF
--- a/.changeset/witty-cooks-visit.md
+++ b/.changeset/witty-cooks-visit.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Fix issue where `_return` (used internally) was not registered as a taglib attribute

--- a/marko.json
+++ b/marko.json
@@ -2,5 +2,10 @@
   "taglibId": "@marko/tags-api-preview",
   "tagsDir": "./src/components",
   "transform": "./src/transform",
-  "translate": "./src/translate"
+  "translate": "./src/translate",
+  "attributes": {
+    "_return": {
+      "type": "expression"
+    }
+  }
 }


### PR DESCRIPTION
## Description

Fix issue where `_return` (used internally) was not registered as a taglib attribute.

Resolves #24 
