### PR TITLE
feat: pin Marko version to latest

### DIFF
--- a/.changeset/tiny-apricots-report.md
+++ b/.changeset/tiny-apricots-report.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Pin peerDependency to current version of Marko.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   ],
   "license": "MIT",
   "main": "marko.json",
+  "peerDependencies": {
+    "marko": "<= 5.21.11"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/marko-js/tags-api-preview"


### PR DESCRIPTION
## Description

Pins the Marko version to the current latest.
There will be a change in the next Marko release that will break the tags api preview.

There will also be a new release of the tags api preview to work with the latest version of Marko.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
