### PR TITLE
Default attr name change

### DIFF
--- a/.changeset/healthy-ravens-wink.md
+++ b/.changeset/healthy-ravens-wink.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": minor
+---
+
+Allow using top level input rather than just <attrs/> tag.

--- a/.changeset/popular-poems-appear.md
+++ b/.changeset/popular-poems-appear.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": minor
+---
+
+Switch to new default attribute name (value instead of default).

--- a/.changeset/shiny-points-reflect.md
+++ b/.changeset/shiny-points-reflect.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": minor
+---
+
+Member expressions now are accounted for when determining function dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.25.0",
-        "@marko/compiler": "^5.22.9",
+        "@marko/compiler": "^5.23.0",
         "@marko/fixture-snapshots": "^2.1.7",
         "@marko/testing-library": "^6.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -41,7 +41,7 @@
         "jsdom": "^20.0.1",
         "jsdom-context-require": "^4.0.6",
         "lint-staged": "^13.0.3",
-        "marko": "^5.21.10",
+        "marko": "^5.22.0",
         "memfs": "^3.4.7",
         "mocha": "^10.1.0",
         "nyc": "^15.1.0",
@@ -53,7 +53,7 @@
         "unionfs": "^4.4.0"
       },
       "peerDependencies": {
-        "marko": "<= 5.21.11"
+        "marko": "> 5.21.11"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/@marko/compiler": {
-      "version": "5.22.9",
-      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.22.9.tgz",
-      "integrity": "sha512-03T5nOkS/VA1jUYWfTMBhbsfUSenCoJ590rzuTDl/9EUp+ZqOmiLvQGmPxvFZA4MQRXQ4ZJGcjOlYQ1427Lhxw==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.23.0.tgz",
+      "integrity": "sha512-bZp4pHREL6IRe7U315XiVIms01k6WxjIvksXvcKnMhREH2ozN6HNotdBNNriP6NtZun1oALLGeoUwVHZXX/Pfg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
@@ -1265,9 +1265,9 @@
       }
     },
     "node_modules/@marko/translator-default": {
-      "version": "5.21.7",
-      "resolved": "https://registry.npmjs.org/@marko/translator-default/-/translator-default-5.21.7.tgz",
-      "integrity": "sha512-qSGC3vHA9y3Rcwi56JuusLxCBjUZoZVTfThwtuMt8NwVhRtRXY3A1vdC1eiDNAlfU4SKhiEqZo5xcSKQOq2dEA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@marko/translator-default/-/translator-default-5.22.0.tgz",
+      "integrity": "sha512-Zbl5rQRL7116d47EuqKU80lzNSvN337jhLd0gBrrpNQ1BFYDgImnSdS0kvlO2TkBaXD7I8CRgkNsdBMhgU4UOw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
@@ -6376,13 +6376,13 @@
       }
     },
     "node_modules/marko": {
-      "version": "5.21.10",
-      "resolved": "https://registry.npmjs.org/marko/-/marko-5.21.10.tgz",
-      "integrity": "sha512-/6owwIKwDxvhPWYrw/DbMpWO5kWvx2FtJfiXamnukcwNdF874qO94fE6GKwv53sXyRuvIaQt9a+1Iy9m32OC7g==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/marko/-/marko-5.22.0.tgz",
+      "integrity": "sha512-8hkiyrz2BSWVsnP0ZPy7VSDQPDHXStbFJ/tecwaLlMlt5unb0F0/M8nAc7bu2Fxx1xEr+FY4q/g4Y+vDrUO5Kw==",
       "dev": true,
       "dependencies": {
-        "@marko/compiler": "^5.22.9",
-        "@marko/translator-default": "^5.21.7",
+        "@marko/compiler": "^5.23.0",
+        "@marko/translator-default": "^5.22.0",
         "app-module-path": "^2.2.0",
         "argly": "^1.2.0",
         "browser-refresh-client": "1.1.4",
@@ -10471,9 +10471,9 @@
       }
     },
     "@marko/compiler": {
-      "version": "5.22.9",
-      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.22.9.tgz",
-      "integrity": "sha512-03T5nOkS/VA1jUYWfTMBhbsfUSenCoJ590rzuTDl/9EUp+ZqOmiLvQGmPxvFZA4MQRXQ4ZJGcjOlYQ1427Lhxw==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.23.0.tgz",
+      "integrity": "sha512-bZp4pHREL6IRe7U315XiVIms01k6WxjIvksXvcKnMhREH2ozN6HNotdBNNriP6NtZun1oALLGeoUwVHZXX/Pfg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.0",
@@ -10609,9 +10609,9 @@
       }
     },
     "@marko/translator-default": {
-      "version": "5.21.7",
-      "resolved": "https://registry.npmjs.org/@marko/translator-default/-/translator-default-5.21.7.tgz",
-      "integrity": "sha512-qSGC3vHA9y3Rcwi56JuusLxCBjUZoZVTfThwtuMt8NwVhRtRXY3A1vdC1eiDNAlfU4SKhiEqZo5xcSKQOq2dEA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@marko/translator-default/-/translator-default-5.22.0.tgz",
+      "integrity": "sha512-Zbl5rQRL7116d47EuqKU80lzNSvN337jhLd0gBrrpNQ1BFYDgImnSdS0kvlO2TkBaXD7I8CRgkNsdBMhgU4UOw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.16.0",
@@ -14346,13 +14346,13 @@
       "dev": true
     },
     "marko": {
-      "version": "5.21.10",
-      "resolved": "https://registry.npmjs.org/marko/-/marko-5.21.10.tgz",
-      "integrity": "sha512-/6owwIKwDxvhPWYrw/DbMpWO5kWvx2FtJfiXamnukcwNdF874qO94fE6GKwv53sXyRuvIaQt9a+1Iy9m32OC7g==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/marko/-/marko-5.22.0.tgz",
+      "integrity": "sha512-8hkiyrz2BSWVsnP0ZPy7VSDQPDHXStbFJ/tecwaLlMlt5unb0F0/M8nAc7bu2Fxx1xEr+FY4q/g4Y+vDrUO5Kw==",
       "dev": true,
       "requires": {
-        "@marko/compiler": "^5.22.9",
-        "@marko/translator-default": "^5.21.7",
+        "@marko/compiler": "^5.23.0",
+        "@marko/translator-default": "^5.22.0",
         "app-module-path": "^2.2.0",
         "argly": "^1.2.0",
         "browser-refresh-client": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.25.0",
-    "@marko/compiler": "^5.22.9",
+    "@marko/compiler": "^5.23.0",
     "@marko/fixture-snapshots": "^2.1.7",
     "@marko/testing-library": "^6.1.2",
     "@testing-library/user-event": "^13.5.0",
@@ -37,7 +37,7 @@
     "jsdom": "^20.0.1",
     "jsdom-context-require": "^4.0.6",
     "lint-staged": "^13.0.3",
-    "marko": "^5.21.10",
+    "marko": "^5.22.0",
     "memfs": "^3.4.7",
     "mocha": "^10.1.0",
     "nyc": "^15.1.0",
@@ -64,7 +64,7 @@
   "license": "MIT",
   "main": "marko.json",
   "peerDependencies": {
-    "marko": "<= 5.21.11"
+    "marko": ">= 5.23.0"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/fixtures/const/__snapshots__/const-extra-attribute-error/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/const/__snapshots__/const-extra-attribute-error/node.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/const/templates/error-extra-attr.marko(1,2): The <const> tag only supports the 'default' attribute.
+src/__tests__/fixtures/const/templates/error-extra-attr.marko(1,2): The <const> tag only supports the 'value' attribute.
 > 1 | <const/x=1 y=2/>
     |  ^^^^^
   2 |

--- a/src/__tests__/fixtures/const/__snapshots__/const-extra-attribute-error/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/const/__snapshots__/const-extra-attribute-error/web.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/const/templates/error-extra-attr.marko(1,2): The <const> tag only supports the 'default' attribute.
+src/__tests__/fixtures/const/templates/error-extra-attr.marko(1,2): The <const> tag only supports the 'value' attribute.
 > 1 | <const/x=1 y=2/>
     |  ^^^^^
   2 |

--- a/src/__tests__/fixtures/effect/__snapshots__/effect-error-extra-attrs/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/effect/__snapshots__/effect-error-extra-attrs/node.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/effect/templates/error-extra-attrs.marko(1,2): The <effect> tag only supports the 'default' attribute.
+src/__tests__/fixtures/effect/templates/error-extra-attrs.marko(1,2): The <effect> tag only supports the 'value' attribute.
 > 1 | <effect=(() => {}) y=1/>
     |  ^^^^^^
   2 | <div/>

--- a/src/__tests__/fixtures/effect/__snapshots__/effect-error-extra-attrs/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/effect/__snapshots__/effect-error-extra-attrs/web.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/effect/templates/error-extra-attrs.marko(1,2): The <effect> tag only supports the 'default' attribute.
+src/__tests__/fixtures/effect/templates/error-extra-attrs.marko(1,2): The <effect> tag only supports the 'value' attribute.
 > 1 | <effect=(() => {}) y=1/>
     |  ^^^^^^
   2 | <div/>

--- a/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/node.render.expected.html
+++ b/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/node.render.expected.html
@@ -1,0 +1,3 @@
+<span>
+  other11
+</span>

--- a/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/web.render.expected.html
+++ b/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/web.render.expected.html
@@ -1,0 +1,3 @@
+<span>
+  other11
+</span>

--- a/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/web.step-0.expected.html
+++ b/src/__tests__/fixtures/effect/__snapshots__/effect-input-member-expression/web.step-0.expected.html
@@ -1,0 +1,3 @@
+<span>
+  other23
+</span>

--- a/src/__tests__/fixtures/effect/index.test.ts
+++ b/src/__tests__/fixtures/effect/index.test.ts
@@ -32,6 +32,27 @@ describe(
 );
 
 describe(
+  "<effect> input member expression",
+  fixture("./templates/input-member-expression.marko", [
+    { onCount, other: "other1", value: { a: 1, b: 2 } },
+    async ({ expect, rerender }) => {
+      expect(onCount).calledOnceWith(2);
+      resetHistory();
+
+      await rerender({ onCount, other: "other2", value: { a: 1, b: 2 } });
+      expect(onCount).has.not.been.called;
+
+      await rerender({ onCount, other: "other2", value: { a: 3, b: 2 } });
+      expect(onCount).has.not.been.called;
+
+      await rerender({ onCount, other: "other2", value: { a: 3, b: 4 } });
+      expect(onCount).calledOnceWith(4);
+      resetHistory();
+    },
+  ])
+);
+
+describe(
   "<effect> no deps",
   fixture("./templates/no-deps.marko", [
     { onMount, onCleanup },

--- a/src/__tests__/fixtures/effect/templates/input-member-expression.marko
+++ b/src/__tests__/fixtures/effect/templates/input-member-expression.marko
@@ -1,0 +1,8 @@
+<span>
+  ${input.other}
+  ${input.value.a}
+</span>
+
+<effect=(() => {
+  input.onCount(input.value.b);
+})/>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-get-extra-attr/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-get-extra-attr/node.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/get-and-set/templates/error-get-extra-attr.marko(2,4): The <get> tag only supports the 'default' attribute.
+src/__tests__/fixtures/get-and-set/templates/error-get-extra-attr.marko(2,4): The <get> tag only supports the 'value' attribute.
   1 | <set=1>
 > 2 |   <get/val="." y=2/>
     |    ^^^

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-get-extra-attr/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-get-extra-attr/web.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/get-and-set/templates/error-get-extra-attr.marko(2,4): The <get> tag only supports the 'default' attribute.
+src/__tests__/fixtures/get-and-set/templates/error-get-extra-attr.marko(2,4): The <get> tag only supports the 'value' attribute.
   1 | <set=1>
 > 2 |   <get/val="." y=2/>
     |    ^^^

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-no-default-attr/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-no-default-attr/node.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/get-and-set/templates/error-set-no-default-attr.marko(1,2): The <set> tag requires a default attribute.
+src/__tests__/fixtures/get-and-set/templates/error-set-no-default-attr.marko(1,2): The <set> tag requires a value attribute.
 > 1 | <set>
     |  ^^^
   2 |   <div/>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-no-default-attr/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-no-default-attr/web.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/get-and-set/templates/error-set-no-default-attr.marko(1,2): The <set> tag requires a default attribute.
+src/__tests__/fixtures/get-and-set/templates/error-set-no-default-attr.marko(1,2): The <set> tag requires a value attribute.
 > 1 | <set>
     |  ^^^
   2 |   <div/>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-spread-attr/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-spread-attr/node.compile.error.expected.txt
@@ -1,5 +1,5 @@
 src/__tests__/fixtures/get-and-set/templates/error-set-spread-attr.marko(2,2): The <set> tag does not support the "...setValue" attribute.
-  1 | <const/setValue = { default: 1 }/>
+  1 | <const/setValue = { value: 1 }/>
 > 2 | <set ...setValue>
     |  ^^^
   3 |   <div/>

--- a/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-spread-attr/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/get-and-set/__snapshots__/error-set-spread-attr/web.compile.error.expected.txt
@@ -1,5 +1,5 @@
 src/__tests__/fixtures/get-and-set/templates/error-set-spread-attr.marko(2,2): The <set> tag does not support the "...setValue" attribute.
-  1 | <const/setValue = { default: 1 }/>
+  1 | <const/setValue = { value: 1 }/>
 > 2 | <set ...setValue>
     |  ^^^
   3 |   <div/>

--- a/src/__tests__/fixtures/get-and-set/index.test.ts
+++ b/src/__tests__/fixtures/get-and-set/index.test.ts
@@ -1,7 +1,7 @@
 import { spy, resetHistory } from "sinon";
 import fixture from "../../fixture";
 
-const defaultChange = spy();
+const valueChange = spy();
 
 describe(
   "<get> & <set> self reference",
@@ -20,16 +20,16 @@ describe(
 describe(
   "<get> & <set> assign to mutable set",
   fixture("./templates/assign-to-mutable-set.marko", [
-    { defaultChange },
+    { valueChange },
     async ({ expect, screen, rerender, fireEvent }) => {
-      expect(defaultChange).has.not.been.called;
+      expect(valueChange).has.not.been.called;
 
       await fireEvent.click(screen.getByText("increment"));
-      expect(defaultChange).calledOnceWith(2);
+      expect(valueChange).calledOnceWith(2);
       resetHistory();
 
       await rerender();
-      expect(defaultChange).has.not.been.called;
+      expect(valueChange).has.not.been.called;
     },
   ])
 );
@@ -37,16 +37,16 @@ describe(
 describe(
   "<get> & <set> assign to nested mutable set",
   fixture("./templates/assign-to-nested-mutable-set.marko", [
-    { defaultChange },
+    { valueChange },
     async ({ expect, screen, rerender, fireEvent }) => {
-      expect(defaultChange).has.not.been.called;
+      expect(valueChange).has.not.been.called;
 
       await fireEvent.click(screen.getByText("increment"));
-      expect(defaultChange).calledOnceWith(2);
+      expect(valueChange).calledOnceWith(2);
       resetHistory();
 
       await rerender();
-      expect(defaultChange).has.not.been.called;
+      expect(valueChange).has.not.been.called;
     },
   ])
 );

--- a/src/__tests__/fixtures/get-and-set/templates/assign-to-mutable-set.marko
+++ b/src/__tests__/fixtures/get-and-set/templates/assign-to-mutable-set.marko
@@ -1,5 +1,5 @@
-<attrs/{ defaultChange }/>
-<set=1 defaultChange=defaultChange>
+<attrs/{ valueChange }/>
+<set=1 valueChange=valueChange>
   <get/val="."/>
   <div>${val}</div>
   <button onClick=(() => val++)>increment</button>

--- a/src/__tests__/fixtures/get-and-set/templates/assign-to-nested-mutable-set.marko
+++ b/src/__tests__/fixtures/get-and-set/templates/assign-to-nested-mutable-set.marko
@@ -1,5 +1,5 @@
-<attrs/{ defaultChange }/>
-<set={ x: 1, xChange: defaultChange }>
+<attrs/{ valueChange }/>
+<set={ x: 1, xChange: valueChange }>
   <get/{ x }="."/>
   <div>${x}</div>
   <button onClick=(() => x++)>increment</button>

--- a/src/__tests__/fixtures/get-and-set/templates/error-set-spread-attr.marko
+++ b/src/__tests__/fixtures/get-and-set/templates/error-set-spread-attr.marko
@@ -1,4 +1,4 @@
-<const/setValue = { default: 1 }/>
+<const/setValue = { value: 1 }/>
 <set ...setValue>
   <div/>
 </set>

--- a/src/__tests__/fixtures/if/__snapshots__/if-error-extra-attr/node.compile.error.expected.txt
+++ b/src/__tests__/fixtures/if/__snapshots__/if-error-extra-attr/node.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/if/templates/error-extra-attr.marko(2,2): The <if> tag only supports the 'default' attribute.
+src/__tests__/fixtures/if/templates/error-extra-attr.marko(2,2): The <if> tag only supports the 'value' attribute.
   1 | <attrs/{ show }/>
 > 2 | <if=show y=2>
     |  ^^

--- a/src/__tests__/fixtures/if/__snapshots__/if-error-extra-attr/web.compile.error.expected.txt
+++ b/src/__tests__/fixtures/if/__snapshots__/if-error-extra-attr/web.compile.error.expected.txt
@@ -1,4 +1,4 @@
-src/__tests__/fixtures/if/templates/error-extra-attr.marko(2,2): The <if> tag only supports the 'default' attribute.
+src/__tests__/fixtures/if/templates/error-extra-attr.marko(2,2): The <if> tag only supports the 'value' attribute.
   1 | <attrs/{ show }/>
 > 2 | <if=show y=2>
     |  ^^

--- a/src/__tests__/fixtures/let/templates/with-default-change.marko
+++ b/src/__tests__/fixtures/let/templates/with-default-change.marko
@@ -1,5 +1,5 @@
 <attrs/{ value, valueChange }/>
-<let/count=value defaultChange=valueChange/>
+<let/count=value valueChange=valueChange/>
 
 <div>${count}</div>
 <button onClick=(() => count++)>Increment</button>

--- a/src/__tests__/fixtures/misc/components/invoke-on-mount.marko
+++ b/src/__tests__/fixtures/misc/components/invoke-on-mount.marko
@@ -1,2 +1,2 @@
-<attrs/{ default: fn }/>
+<attrs/{ value: fn }/>
 <lifecycle onMount=fn/>

--- a/src/__tests__/fixtures/misc/components/invoke.marko
+++ b/src/__tests__/fixtures/misc/components/invoke.marko
@@ -1,2 +1,2 @@
-<attrs/{ default: fn }/>
+<attrs/{ value: fn }/>
 <const/data = fn()/>

--- a/src/__tests__/fixtures/misc/components/repeat.marko
+++ b/src/__tests__/fixtures/misc/components/repeat.marko
@@ -1,4 +1,4 @@
-<attrs/{ default: times, renderBody }/>
+<attrs/{ value: times, renderBody }/>
 <for|i| from=0 to=times>
   <${renderBody}=[i]/>
 </for>

--- a/src/__tests__/fixtures/misc/feature-detect/index.test.ts
+++ b/src/__tests__/fixtures/misc/feature-detect/index.test.ts
@@ -49,11 +49,6 @@ describe("misc feature detect", () => {
   );
 
   describe(
-    "error reference input",
-    fixture("./templates/error-feature-detect-reference-input.marko")
-  );
-
-  describe(
     "error reference out",
     fixture("./templates/error-feature-detect-reference-out.marko")
   );

--- a/src/__tests__/fixtures/return/templates/components/read-write-clamped.marko
+++ b/src/__tests__/fixtures/return/templates/components/read-write-clamped.marko
@@ -1,3 +1,3 @@
 <attrs/{ max }/>
 <let/x=1/>
-<return = x defaultChange=(v => x = Math.min(v, max))/>
+<return = x valueChange=(v => x = Math.min(v, max))/>

--- a/src/__tests__/fixtures/return/templates/components/read-write.marko
+++ b/src/__tests__/fixtures/return/templates/components/read-write.marko
@@ -1,2 +1,2 @@
 <let/x=1/>
-<return = x defaultChange=(v => x = v)/>
+<return = x valueChange=(v => x = v)/>

--- a/src/components/const/marko-tag.json
+++ b/src/components/const/marko-tag.json
@@ -1,6 +1,6 @@
 {
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [

--- a/src/components/const/translate.ts
+++ b/src/components/const/translate.ts
@@ -5,13 +5,13 @@ import assertNoAssignments from "../../util/assert-no-assignments";
 
 export = (tag: t.NodePath<t.MarkoTag>) => {
   const tagVar = tag.node.var!;
-  const defaultAttr = getAttr(tag, "default")!;
+  const valueAttr = getAttr(tag, "value")!;
   const errorMessage = !tagVar
     ? "requires a tag variable to be assigned to"
-    : !defaultAttr
+    : !valueAttr
     ? "must be initialized with a value"
     : tag.node.attributes.length > 1
-    ? "only supports the 'default' attribute"
+    ? "only supports the 'value' attribute"
     : tag.node.body.body.length
     ? "does not support body content"
     : tag.node.body.params.length
@@ -32,7 +32,7 @@ export = (tag: t.NodePath<t.MarkoTag>) => {
     t.variableDeclaration("const", [
       t.variableDeclarator(
         tagVar,
-        deepFreeze(tag.hub.file, defaultAttr.node.value)
+        deepFreeze(tag.hub.file, valueAttr.node.value)
       ),
     ])
   );

--- a/src/components/effect/marko-tag.json
+++ b/src/components/effect/marko-tag.json
@@ -1,6 +1,6 @@
 {
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [

--- a/src/components/effect/translate.ts
+++ b/src/components/effect/translate.ts
@@ -5,13 +5,13 @@ import getAttr from "../../util/get-attr";
 export = function translate(tag: t.NodePath<t.MarkoTag>) {
   const { file } = tag.hub;
 
-  const defaultAttr = getAttr(tag, "default")!;
+  const valueAttr = getAttr(tag, "value")!;
   const errorMessage = tag.node.var
     ? "does not support a tag variable"
-    : !defaultAttr
+    : !valueAttr
     ? "must be initialized with a value"
     : tag.node.attributes.length > 1
-    ? "only supports the 'default' attribute"
+    ? "only supports the 'value' attribute"
     : tag.node.body.body.length
     ? "does not support body content"
     : tag.node.body.params.length
@@ -37,7 +37,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
         importRuntimeDefault(file, "components/effect", "effect"),
         [
           (file as any)._componentInstanceIdentifier,
-          getAttr(tag, "default")!.node.value,
+          getAttr(tag, "value")!.node.value,
         ]
       )
     )

--- a/src/components/get/index.marko
+++ b/src/components/get/index.marko
@@ -8,11 +8,11 @@ class {
     this.sync = this.sync.bind(this);
   }
   onInput(input, out) {
-    var from = input.default;
+    var from = input.value;
 
     if (!from || !from.render) {
       throw new Error(
-        "Invalid component constructor provided as <get> 'default' attribute. Got: " +
+        "Invalid component constructor provided as <get> 'value' attribute. Got: " +
           from
       );
     }
@@ -38,8 +38,8 @@ class {
     var prevData = this.data;
     this.data = this.provider.input;
     if (
-      this.data.default !== prevData.default ||
-      this.data.defaultChange !== prevData.defaultChange
+      this.data.value !== prevData.value ||
+      this.data.valueChange !== prevData.valueChange
     ) {
       this.forceUpdate();
       this.update();
@@ -48,4 +48,4 @@ class {
 }
 
 $ var data = component.data || {};
-<${input.renderBody}(data.default, data.defaultChange)/>
+<${input.renderBody}(data.value, data.valueChange)/>

--- a/src/components/get/marko-tag.json
+++ b/src/components/get/marko-tag.json
@@ -2,7 +2,7 @@
   "template": "./index.marko",
   "transform": "./transform",
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [

--- a/src/components/get/transform.ts
+++ b/src/components/get/transform.ts
@@ -5,10 +5,10 @@ import getAttr from "../../util/get-attr";
 
 export = function transform(tag: t.NodePath<t.MarkoTag>) {
   const file = tag.hub.file;
-  const defaultAttr = getAttr(tag, "default")!;
+  const valueAttr = getAttr(tag, "value")!;
   const errorMessage =
-    defaultAttr && tag.node.attributes.length > 1
-      ? "only supports the 'default' attribute"
+    valueAttr && tag.node.attributes.length > 1
+      ? "only supports the 'value' attribute"
       : !tag.node.var
       ? "requires a tag variable"
       : tag.node.arguments
@@ -23,7 +23,7 @@ export = function transform(tag: t.NodePath<t.MarkoTag>) {
     throw tag.get("name").buildCodeFrameError(`The <get> tag ${errorMessage}.`);
   }
 
-  if (!defaultAttr) {
+  if (!valueAttr) {
     for (const name in tag.get("var").getBindingIdentifiers()) {
       for (const violation of tag.scope.getOwnBinding(name)!
         .constantViolations) {
@@ -46,7 +46,7 @@ export = function transform(tag: t.NodePath<t.MarkoTag>) {
     return;
   }
 
-  let fromValue = defaultAttr.node.value;
+  let fromValue = valueAttr.node.value;
 
   if (t.isStringLiteral(fromValue)) {
     const literalValue = fromValue.value;
@@ -64,12 +64,12 @@ export = function transform(tag: t.NodePath<t.MarkoTag>) {
       if (fromTag) {
         fromValue = importDefault(file, `<${literalValue}>`, "context");
       } else {
-        throw defaultAttr.buildCodeFrameError(
+        throw valueAttr.buildCodeFrameError(
           `<get> could not find provider matching "${literalValue}".`
         );
       }
     }
 
-    defaultAttr.set("value", fromValue);
+    valueAttr.set("value", fromValue);
   }
 };

--- a/src/components/if/transformer.ts
+++ b/src/components/if/transformer.ts
@@ -8,15 +8,15 @@ export = function transform(tag: t.NodePath<t.MarkoTag>) {
   if (isApi(tag, "class") || seen.has(tag)) return;
   seen.add(tag);
 
-  const defaultAttr = getAttr(tag, "default")!;
+  const valueAttr = getAttr(tag, "value")!;
   const errorMessage = tag.node.var
     ? "does not support a tag variable"
     : tag.node.arguments?.length
     ? "does not support arguments, the tags api uses '<if=condition>' instead"
-    : !defaultAttr
+    : !valueAttr
     ? "must be given a value"
     : tag.node.attributes.length > 1
-    ? "only supports the 'default' attribute"
+    ? "only supports the 'value' attribute"
     : !tag.node.body.body.length
     ? "requires body content"
     : tag.node.body.params.length
@@ -31,6 +31,6 @@ export = function transform(tag: t.NodePath<t.MarkoTag>) {
       );
   }
 
-  tag.node.arguments = [defaultAttr.node.value];
+  tag.node.arguments = [valueAttr.node.value];
   tag.node.attributes = [];
 };

--- a/src/components/let/marko-tag.json
+++ b/src/components/let/marko-tag.json
@@ -1,6 +1,6 @@
 {
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [
@@ -9,7 +9,7 @@
       }
     ]
   },
-  "@defaultChange": {
+  "@valueChange": {
     "type": "expression",
     "autocomplete": [
       {

--- a/src/components/let/translate.ts
+++ b/src/components/let/translate.ts
@@ -7,17 +7,17 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
   const { file } = tag.hub;
   const server = file.markoOpts.output === "html";
   const tagVar = tag.node.var as t.Identifier;
-  let defaultAttr: t.NodePath<t.MarkoAttribute> | undefined;
+  let valueAttr: t.NodePath<t.MarkoAttribute> | undefined;
   let changeAttr: t.NodePath<t.MarkoAttribute> | undefined;
   let errorMessage: string | undefined;
 
   for (const attr of tag.get("attributes")) {
     if (attr.isMarkoAttribute()) {
       switch (attr.node.name) {
-        case "default":
-          defaultAttr = attr;
+        case "value":
+          valueAttr = attr;
           continue;
-        case "defaultChange":
+        case "valueChange":
           changeAttr = attr;
           continue;
       }
@@ -46,8 +46,8 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
   }
 
   file.path.scope.crawl();
-  const defaultValue = defaultAttr
-    ? defaultAttr.node.value
+  const value = valueAttr
+    ? valueAttr.node.value
     : t.unaryExpression("void", t.numericLiteral(0));
   const binding = tag.scope.getBinding(tagVar.name)!;
 
@@ -55,7 +55,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
     file.path.scope.crawl();
     tag.replaceWith(
       t.variableDeclaration("const", [
-        t.variableDeclarator(tagVar, deepFreeze(file, defaultValue)),
+        t.variableDeclarator(tagVar, deepFreeze(file, value)),
       ])
     );
   } else {
@@ -68,7 +68,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
       t.assignmentExpression(
         "=",
         t.memberExpression(meta.state, keyString, true),
-        deepFreeze(file, defaultValue)
+        deepFreeze(file, value)
       )
     );
 
@@ -83,7 +83,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
 
       if (t.isFunction(changeAttr.node.value)) {
         setFnId = changeFnId;
-        decls.push(t.variableDeclarator(tagVar, defaultValue));
+        decls.push(t.variableDeclarator(tagVar, value));
       } else {
         setFnId = tag.scope.generateUidIdentifier(`${tagVar.name}Set`);
         decls.push(
@@ -103,7 +103,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
           ),
           t.variableDeclarator(
             tagVar,
-            t.conditionalExpression(changeFnId, defaultValue, getStateExpr)
+            t.conditionalExpression(changeFnId, value, getStateExpr)
           )
         );
       }

--- a/src/components/return/index-browser.ts
+++ b/src/components/return/index-browser.ts
@@ -43,8 +43,8 @@ function createReturn(component: Component) {
     if (write) {
       if (
         curValue &&
-        (curValue.default !== newVal!.default ||
-          curValue.defaultChange !== newVal!.defaultChange)
+        (curValue.value !== newVal!.value ||
+          curValue.valueChange !== newVal!.valueChange)
       ) {
         component.forceUpdate();
       }

--- a/src/components/return/marko-tag.json
+++ b/src/components/return/marko-tag.json
@@ -1,6 +1,6 @@
 {
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [
@@ -9,7 +9,7 @@
       }
     ]
   },
-  "@defaultChange": {
+  "@valueChange": {
     "type": "expression",
     "autocomplete": [
       {

--- a/src/components/set/marko-tag.json
+++ b/src/components/set/marko-tag.json
@@ -1,7 +1,7 @@
 {
   "template": "./index.marko",
   "translate": "./translate",
-  "@default": {
+  "@value": {
     "type": "expression",
     "required": true,
     "autocomplete": [
@@ -10,7 +10,7 @@
       }
     ]
   },
-  "@defaultChange": {
+  "@valueChange": {
     "type": "expression",
     "autocomplete": [
       {

--- a/src/components/set/translate.ts
+++ b/src/components/set/translate.ts
@@ -9,8 +9,8 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
   for (const attr of tag.get("attributes")) {
     if (attr.isMarkoAttribute()) {
       switch (attr.node.name) {
-        case "default":
-        case "defaultChange":
+        case "value":
+        case "valueChange":
           continue;
       }
     }
@@ -22,7 +22,7 @@ export = function translate(tag: t.NodePath<t.MarkoTag>) {
   errorMessage =
     errorMessage ||
     (!tag.node.attributes.length
-      ? "requires a default attribute"
+      ? "requires a value attribute"
       : tag.node.var
       ? "does not support a tag variable"
       : tag.node.arguments?.length

--- a/src/transform/cached-function/transform.ts
+++ b/src/transform/cached-function/transform.ts
@@ -1,52 +1,61 @@
 import { isNativeTag, isDynamicTag } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import { importRuntimeNamed } from "../../util/import-runtime";
-import isCoreTag from "../../util/is-core-tag";
-import getAttr from "../../util/get-attr";
 import isApi from "../../util/is-api";
 import { ensureLifecycle } from "../wrapper-component";
-type DepsVisitorState =
-  | { root: t.NodePath; shallow?: undefined; deps?: Set<string> }
-  | { root: t.NodePath; shallow: true; deps?: true };
+
+interface Deps {
+  [x: string]: Deps | true;
+}
+interface DepsVisitorState {
+  parentTag: t.NodePath;
+  rootFn: t.NodePath;
+  deps?: Deps;
+}
 
 const depsVisitor = {
   Function(fn, state) {
-    if (fn === state.root) fn.skip();
+    if (fn === state.rootFn) fn.skip();
   },
   ReferencedIdentifier: ((identifier, state) => {
-    const { name } = identifier.node;
+    let { name } = identifier.node;
     const binding = identifier.scope.getBinding(name);
-    if (binding) {
-      const bindingTag = binding.path;
 
-      if (
-        bindingTag.isMarkoTag() &&
-        !(isNativeTag(bindingTag) || isDynamicTag(bindingTag))
-      ) {
-        let isDep = false;
+    if (
+      binding
+        ? binding.path.isMarkoTag() &&
+          !(
+            binding.path === state.parentTag ||
+            isNativeTag(binding.path) ||
+            isDynamicTag(binding.path)
+          )
+        : name === "input"
+    ) {
+      let deps = state.deps || (state.deps = {});
+      let parent = identifier.parentPath;
 
-        if (isCoreTag("const", binding.path)) {
-          // Const tag reflects the default value as dependencies.
-          const nestedState: DepsVisitorState = state.shallow
-            ? state
-            : { root: state.root, shallow: true };
-          getAttr(bindingTag, "value")!.traverse(depsVisitor, nestedState);
-          isDep = !!nestedState.deps;
+      do {
+        const curDeps = deps[name];
+        if (curDeps === true) return;
+
+        if (
+          parent.isMemberExpression() &&
+          (!parent.node.computed ||
+            isStringOrNumericLiteral(parent.node.property.type))
+        ) {
+          const prop = parent.node.property as
+            | t.Identifier
+            | t.StringLiteral
+            | t.NumericLiteral;
+          parent = parent.parentPath;
+          deps = curDeps || (deps[name] = {} as Deps);
+          name = prop.type === "Identifier" ? prop.name : prop.value + "";
         } else {
-          isDep = true;
+          deps[name] = true;
+          return;
         }
-
-        if (isDep) {
-          if (state.shallow) {
-            state.deps = true;
-            identifier.stop();
-          } else {
-            ((state.deps || (state.deps = new Set())) as Set<string>).add(
-              identifier.node.name
-            );
-          }
-        }
-      }
+        // eslint-disable-next-line no-constant-condition
+      } while (true);
     }
   }) as t.Visitor<DepsVisitorState>["Identifier"],
 } as t.Visitor<DepsVisitorState>;
@@ -63,7 +72,7 @@ export default {
       return;
     }
 
-    const state: DepsVisitorState & { deps?: Set<string> } = { root: fn };
+    const state: DepsVisitorState = { rootFn: fn, parentTag };
     fn.skip();
     fn.traverse(depsVisitor, state);
 
@@ -80,9 +89,7 @@ export default {
               importRuntimeNamed(file, "transform/cached-function", "cached"),
               [
                 component,
-                t.arrayExpression(
-                  state.deps ? Array.from(state.deps, toIdentifier) : []
-                ),
+                t.arrayExpression(state.deps ? toDepsArray(state.deps) : []),
               ]
             ),
             fn.node
@@ -93,6 +100,33 @@ export default {
   },
 } as t.Visitor;
 
-function toIdentifier(val: string) {
-  return t.identifier(val);
+function isStringOrNumericLiteral(type: string) {
+  switch (type) {
+    case "StringLiteral":
+    case "NumericLiteral":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function toDepsArray(
+  deps: Deps,
+  object?: t.Expression,
+  arr: (t.Identifier | t.MemberExpression)[] = []
+) {
+  for (const name in deps) {
+    const dep = deps[name];
+    const node = object
+      ? t.memberExpression(object, t.stringLiteral(name), true)
+      : t.identifier(name);
+
+    if (dep === true) {
+      arr.push(node);
+    } else {
+      toDepsArray(dep, node, arr);
+    }
+  }
+
+  return arr;
 }

--- a/src/transform/cached-function/transform.ts
+++ b/src/transform/cached-function/transform.ts
@@ -30,7 +30,7 @@ const depsVisitor = {
           const nestedState: DepsVisitorState = state.shallow
             ? state
             : { root: state.root, shallow: true };
-          getAttr(bindingTag, "default")!.traverse(depsVisitor, nestedState);
+          getAttr(bindingTag, "value")!.traverse(depsVisitor, nestedState);
           isDep = !!nestedState.deps;
         } else {
           isDep = true;

--- a/src/transform/custom-tag-var.ts
+++ b/src/transform/custom-tag-var.ts
@@ -18,7 +18,7 @@ export default {
       const { node } = tag;
       const tagVar = node.var as t.PatternLike;
       const tagVarReplacement = t.objectPattern([
-        t.objectProperty(t.identifier("default"), tagVar),
+        t.objectProperty(t.identifier("value"), tagVar),
       ]);
       const meta = closest(tag.parentPath)!;
       const returnValueId = tag.scope.generateUidIdentifier(

--- a/src/transform/feature-detection.ts
+++ b/src/transform/feature-detection.ts
@@ -30,7 +30,7 @@ const featureDetectionVisitor = {
     const name = ref.node.name;
 
     if (
-      (name === "input" || name === "component" || name === "out") &&
+      (name === "component" || name === "out") &&
       !ref.scope.hasBinding(name)
     ) {
       addFeature(state, "class", `${name} template global`, ref);

--- a/src/transform/tag-body-parameters.ts
+++ b/src/transform/tag-body-parameters.ts
@@ -28,7 +28,7 @@ export default {
       t.assignmentPattern(
         t.objectPattern([
           t.objectProperty(
-            t.identifier("default"),
+            t.identifier("value"),
             t.assignmentPattern(
               t.arrayPattern(body.node.params as t.PatternLike[]),
               t.arrayExpression([])


### PR DESCRIPTION
* Allow using top level input rather than just <attrs/> tag.
* Switch to new default attribute name (value instead of default).
* Member expressions now are accounted for when determining function dependencies.