### PR TITLE
fix: "Unused '@ts-expect-error' directive" compilation error

### DIFF
--- a/.changeset/thin-dots-agree.md
+++ b/.changeset/thin-dots-agree.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Fix "Unused '@ts-expect-error' directive" compilation error when noUnusedParameters is false

--- a/src/components/get/index.d.marko
+++ b/src/components/get/index.d.marko
@@ -1,4 +1,4 @@
-// @ts-expect-error 'VariableType' is declared but its value is never read. (It is only used to set the type of the return)
+// @ts-ignore We need to ignore instead of -expect-error because the error only happens when noUnusedParameters compiler option is true
 export interface Input<VariableType = unknown> {
   value: string;
 }


### PR DESCRIPTION
Version `0.7.3` of `tags-api-preview` introduced a bug with the change to `<get>` adding support for return type parameter :/

The `@ts-expect-error` [in the code here](https://github.com/svallory/marko-tags-api-preview/blob/main/src/components/get/index.d.marko#L1) breaks compilation of projects using tags preview when their `tsconfig` has `compilerOptions.noUnusedParameters` set to `false`. Example:

```
node_modules/@marko/tags-api-preview/dist/components/get/index.d.marko:1:1 - error TS2578

> 1 | // @ts-expect-error 'VariableType' is declared but its value is never read. (It is only used to set the type of the return
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Unused '@ts-expect-error' directive.
  2 | export interface Input<VariableType = unknown> {
  3 |   value: string;
  4 | }
```

The only reliable approach here is to use `@ts-ignore` so compilation succeeds regardless of the `noUnusedParameters` value