### PR TITLE
fix: Use let instead of const for let tags on the server

### DIFF
--- a/.changeset/eleven-dots-kick.md
+++ b/.changeset/eleven-dots-kick.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Fix const reassignment when using the let tag and spread attributes

--- a/src/components/let/translate.ts
+++ b/src/components/let/translate.ts
@@ -54,7 +54,7 @@ export default function translate(tag: t.NodePath<t.MarkoTag>) {
   if (server) {
     file.path.scope.crawl();
     tag.replaceWith(
-      t.variableDeclaration("const", [
+      t.variableDeclaration("let", [
         t.variableDeclarator(tagVar, deepFreeze(file, value)),
       ]),
     );


### PR DESCRIPTION
This resolves an issue where the compiled server code reassigns const variables by using `let` instead of `const`.

Resolves https://github.com/marko-js/tags-api-preview/issues/56.

