### PR TITLE
fix: tell @marko/compiler about function event handlers

### DIFF
--- a/.changeset/fifty-years-sneeze.md
+++ b/.changeset/fifty-years-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@marko/tags-api-preview": patch
+---
+
+Use `meta.hasFunctionEventHandlers` from recent marko releases when we detect an event or change handler to ensure the template is marked for client side compilation.`

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -2,12 +2,14 @@ import type { types as t } from "@marko/compiler";
 import wrapperComponent from "./wrapper-component";
 import cachedValues from "./cached-values/transform";
 import nativeTagVar from "./native-tag-var/transform";
+import nativeTagHandlers from "./track-function-handlers";
 import hoistTagVars from "./hoist-tag-vars/transform";
 import featureDetection from "./feature-detection";
 import tagBodyParameters from "./tag-body-parameters";
 import customTagVar from "./custom-tag-var";
 import assignmentsToChangeCall from "./assignments-to-change-call";
 import attributeBindings from "./attribute-bindings";
+import trackFunctionHandlers from "./track-function-handlers";
 
 export default [
   featureDetection,
@@ -17,6 +19,8 @@ export default [
   hoistTagVars,
   attributeBindings,
   nativeTagVar,
+  nativeTagHandlers,
   customTagVar,
   tagBodyParameters,
+  trackFunctionHandlers,
 ] as t.Visitor[];

--- a/src/transform/track-function-handlers.ts
+++ b/src/transform/track-function-handlers.ts
@@ -1,0 +1,25 @@
+import { types as t } from "@marko/compiler";
+import isApi from "../util/is-api";
+const eventNameReg = /^on[A-Z]/;
+const changeNameReg = /Change$/;
+
+export default {
+  MarkoTag(tag: t.NodePath<t.MarkoTag>) {
+    if (isApi(tag, "tags")) {
+      // Tells Marko that this tag uses event handlers.
+      const file = tag.hub.file;
+      const meta = file.metadata.marko as any;
+      if (!meta.hasFunctionEventHandlers) {
+        for (const attr of tag.node.attributes) {
+          if (
+            t.isMarkoAttribute(attr) &&
+            (eventNameReg.test(attr.name) || changeNameReg.test(attr.name))
+          ) {
+            meta.hasFunctionEventHandlers = true;
+            break;
+          }
+        }
+      }
+    }
+  },
+} as t.Visitor;


### PR DESCRIPTION
Use `meta.hasFunctionEventHandlers` from recent marko releases when we detect an event or change handler to ensure the template is marked for client side compilation.

Resolves #65
Resolves #14
Resolves #13